### PR TITLE
Remove duplicate assignment of oi

### DIFF
--- a/ed2016/src/CommandBase.cpp
+++ b/ed2016/src/CommandBase.cpp
@@ -37,7 +37,6 @@ void CommandBase::init()
 	climber = Climber::getInstance();
 	sensors = Sensors::getInstance();
 	shooter = Shooter::getInstance();
-	oi = OI::getInstance();
 	cameras = Cameras::getInstance();
 	intake = Intake::getInstance();
 }


### PR DESCRIPTION
It will not make any real difference to functionality, because OI::getInstance() will only instantiate one instance of an OI object, but it certainly is strange to see it being assigned to the same variable more than once.
